### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.4.1, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.1](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.0...v0.4.1)
+_28 September 2024_
+
+### Fixed
+
+* Only test `mod debug` with feature `parser`
+* Only compile `mod debug` on feature `parser`
+* Elided lifetimes must be explicit in Rust nightly
+
+### Other
+
+* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
+* Add two parsing benchmarks ([#9](https://github.com/scouten-adobe/jumbf-rs/pull/9))
+* (IGNORE) Add example of parsing a more complex data structure ([#10](https://github.com/scouten-adobe/jumbf-rs/pull/10))
+* (IGNORE) Update for recent changes to cargo-deny ([#8](https://github.com/scouten-adobe/jumbf-rs/pull/8))
+
 ## 0.4.0
 _27 March 2024_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jumbf"
-version = "0.4.0"
+version = "0.4.1"
 description = "A JUMBF (ISO/IEC 19566-5:2023) parser and builder written in pure Rust."
 repository = "https://github.com/scouten-adobe/jumbf-rs"
 documentation = "https://docs.rs/jumbf"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,7 @@ body = """
 ## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %}
 _{{ timestamp | date(format="%d %B %Y") }}_
 {% for group, commits in commits | group_by(attribute="group") %}
-{%- if group != "chore" -%}
+{% if group != "chore" %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
 {%- if commit.scope and commit.scope != package -%}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,16 +4,28 @@ body = """
 ## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %}
 _{{ timestamp | date(format="%d %B %Y") }}_
 {% for group, commits in commits | group_by(attribute="group") %}
+{%- if group != "chore" -%}
 ### {{ group | upper_first }}
 {% for commit in commits %}
 {%- if commit.scope and commit.scope != package -%}
-* *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+* *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ upper_first(commit.message) }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}
-* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+* {% if commit.breaking %}[**breaking**] {% endif %}{{ upper_first(commit.message) }}
 {% endif -%}
+{%- endif -%}
 {% endfor -%}
 {% endfor %}
 """
+
+commit_parsers = [
+  { message = "^feat", group = "added" },
+  { message = "^changed", group = "changed" },
+  { message = "^deprecated", group = "deprecated" },
+  { message = "^fix", group = "fixed" },
+  { message = "^security", group = "security" },
+  { message = "^chore", group = "chore" },
+  { message = "^.*", group = "other" },
+]
 
 [workspace]
 dependencies_update = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,7 +6,7 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | upper_first }}
 {% for commit in commits %}
-{%- if commit.scope -%}
+{%- if commit.scope and commit.scope != package -%}
 * *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}
 * {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
@@ -16,4 +16,7 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 """
 
 [workspace]
+dependencies_update = true
+features_always_increment_minor = true
+release_always = false
 release_commits = "^(feat|fix)[(:]"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,7 +13,7 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 * {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
 {% endif -%}
 {% endfor -%}
-{%- endif -%}
+{% endif -%}
 {% endfor %}
 """
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,10 +3,11 @@ body = """
 
 ## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %}
 _{{ timestamp | date(format="%d %B %Y") }}_
-{% for group, commits in commits | group_by(attribute="group") %}
+{%- for group, commits in commits | group_by(attribute="group") %}
 {% if group != "chore" -%}
 ### {{ group | upper_first }}
-{% for commit in commits %}
+
+{%- for commit in commits [%}
 {%- if commit.scope and commit.scope != package -%}
 * *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,9 +8,9 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 ### {{ group | upper_first }}
 {% for commit in commits %}
 {%- if commit.scope and commit.scope != package -%}
-* *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ upper_first(commit.message) }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+* *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}
-* {% if commit.breaking %}[**breaking**] {% endif %}{{ upper_first(commit.message) }}
+* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
 {% endif -%}
 {%- endif -%}
 {% endfor -%}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,7 +7,7 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 {% if group != "chore" -%}
 ### {{ group | upper_first }}
 
-{%- for commit in commits %}
+{% for commit in commits -%}
 {%- if commit.scope and commit.scope != package -%}
 * *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,8 +12,8 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 {% else -%}
 * {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}
 {% endif -%}
-{%- endif -%}
 {% endfor -%}
+{%- endif -%}
 {% endfor %}
 """
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,7 +7,7 @@ _{{ timestamp | date(format="%d %B %Y") }}_
 {% if group != "chore" -%}
 ### {{ group | upper_first }}
 
-{%- for commit in commits [%}
+{%- for commit in commits %}
 {%- if commit.scope and commit.scope != package -%}
 * *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% else -%}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -4,7 +4,7 @@ body = """
 ## [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %}
 _{{ timestamp | date(format="%d %B %Y") }}_
 {% for group, commits in commits | group_by(attribute="group") %}
-{% if group != "chore" %}
+{% if group != "chore" -%}
 ### {{ group | upper_first }}
 {% for commit in commits %}
 {%- if commit.scope and commit.scope != package -%}


### PR DESCRIPTION
## 🤖 New release
* `jumbf`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.0...v0.4.1)

_28 September 2024_

### Fixed

* Only test `mod debug` with feature `parser`
* Only compile `mod debug` on feature `parser`
* Elided lifetimes must be explicit in Rust nightly

### Other

* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
* Add two parsing benchmarks ([#9](https://github.com/scouten-adobe/jumbf-rs/pull/9))
* (IGNORE) Add example of parsing a more complex data structure ([#10](https://github.com/scouten-adobe/jumbf-rs/pull/10))
* (IGNORE) Update for recent changes to cargo-deny ([#8](https://github.com/scouten-adobe/jumbf-rs/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).