### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ _28 September 2024_
 ## 0.4.0
 _27 March 2024_
 
-* (MINOR) Add ChildBox.as_super_box() and .as_data_box() methods ([#7](https://github.com/scouten-adobe/jumbf-rs/pull/7))
+* Add `ChildBox.as_super_box()` and `.as_data_box()` methods ([#7](https://github.com/scouten-adobe/jumbf-rs/pull/7))
 
 ## 0.3.0
 _22 March 2024_
 
-* Add an example for offset_within_superbox ([#6](https://github.com/scouten-adobe/jumbf-rs/pull/6))
-* (MINOR) DataBox: Add new function offset_within_superbox ([#5](https://github.com/scouten-adobe/jumbf-rs/pull/5))
+* Add an example for 1offset_within_superbox` ([#6](https://github.com/scouten-adobe/jumbf-rs/pull/6))
+* `DataBox`: Add new function `offset_within_superbox` ([#5](https://github.com/scouten-adobe/jumbf-rs/pull/5))
 
 ## 0.2.2
 _13 March 2024_
@@ -52,9 +52,9 @@ _13 March 2024_
 _13 March 2024_
 
 * Add ability to limit recursion when parsing superboxes ([#3](https://github.com/scouten-adobe/jumbf-rs/pull/3))
-* (MINOR) Change `SuperBox::from_box` to `SuperBox::from_data_box` ([#4](https://github.com/scouten-adobe/jumbf-rs/pull/4))
+* Change `SuperBox::from_box` to `SuperBox::from_data_box` ([#4](https://github.com/scouten-adobe/jumbf-rs/pull/4))
 * Add more examples to readme
-* (MINOR) Rename `Box` to `DataBox` ([#1](https://github.com/scouten-adobe/jumbf-rs/pull/1))
+* Rename `Box` to `DataBox` ([#1](https://github.com/scouten-adobe/jumbf-rs/pull/1))
 
 ## 0.1.0
 _12 March 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All changes to this project are documented in this file.
+All notable changes to this project are documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org), except that – as is typical in the Rust community – the minimum supported Rust version may be increased without a major version increase.
 
@@ -14,13 +14,18 @@ _28 September 2024_
 * Only test `mod debug` with feature `parser`
 * Only compile `mod debug` on feature `parser`
 * Elided lifetimes must be explicit in Rust nightly
+* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
 
 ### Other
 
-* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
 * Add two parsing benchmarks ([#9](https://github.com/scouten-adobe/jumbf-rs/pull/9))
-* (IGNORE) Add example of parsing a more complex data structure ([#10](https://github.com/scouten-adobe/jumbf-rs/pull/10))
-* (IGNORE) Update for recent changes to cargo-deny ([#8](https://github.com/scouten-adobe/jumbf-rs/pull/8))
+* Numerous changes to build infrastructure
+  * Start using [release-plz](https://release-plz.ieni.dev) for release management
+  * Start using [commitlint-rs](https://keisukeyamashita.github.io/commitlint-rs/) for PR title validation
+  * Start using Dependabot to track GitHub Actions upgrades
+  * Update to latest version of cargo-deny, actions/checkout, codecov/codecov-action, CodSpeedHQ/action
+  * Remove deprecated actions-rs/clippy-check action
+  * Remove nightly build task
 
 ## 0.4.0
 _27 March 2024_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ This project adheres to [Semantic Versioning](https://semver.org), except that â
 
 Since version 0.4.1, the format of this changelog is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.4.1](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.0...v0.4.1)
+_28 September 2024_
+
+### Fixed
+
+* Only test `mod debug` with feature `parser`
+* Only compile `mod debug` on feature `parser`
+* Elided lifetimes must be explicit in Rust nightly
+
+### Other
+
+* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
+* Add two parsing benchmarks ([#9](https://github.com/scouten-adobe/jumbf-rs/pull/9))
+* (IGNORE) Add example of parsing a more complex data structure ([#10](https://github.com/scouten-adobe/jumbf-rs/pull/10))
+* (IGNORE) Update for recent changes to cargo-deny ([#8](https://github.com/scouten-adobe/jumbf-rs/pull/8))
+
 ## 0.4.0
 _27 March 2024_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jumbf"
-version = "0.4.0"
+version = "0.4.1"
 description = "A JUMBF (ISO/IEC 19566-5:2023) parser and builder written in pure Rust."
 repository = "https://github.com/scouten-adobe/jumbf-rs"
 documentation = "https://docs.rs/jumbf"


### PR DESCRIPTION
## 🤖 New release
* `jumbf`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.0...v0.4.1)

_28 September 2024_

### Fixed

* Only test `mod debug` with feature `parser`
* Only compile `mod debug` on feature `parser`
* Elided lifetimes must be explicit in Rust nightly

### Other

* Fix benchmark invocations ([#12](https://github.com/scouten-adobe/jumbf-rs/pull/12))
* Add two parsing benchmarks ([#9](https://github.com/scouten-adobe/jumbf-rs/pull/9))
* (IGNORE) Add example of parsing a more complex data structure ([#10](https://github.com/scouten-adobe/jumbf-rs/pull/10))
* (IGNORE) Update for recent changes to cargo-deny ([#8](https://github.com/scouten-adobe/jumbf-rs/pull/8))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).