### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 As of January 2026 and until the 1.0.0 version is released, the authors will only make minor version changes (incrementing the `x` in `0.x.0`) if breaking changes are made (including changing the minimum supported Rust version). Features will now result in a patch version change (incrementing the `y` in `0.x.y`). This brings us into closer compliance with typical SemVer practice (and follows the default behavior of [`release-plz`](https://release-plz.dev/docs/config#the-features_always_increment_minor-field).
 
+## [0.5.0](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.1...v0.5.0)
+_22 January 2026_
+
+### Added
+
+* [**breaking**] Bump MSRV to 1.88.0 ([#47](https://github.com/scouten-adobe/jumbf-rs/pull/47))
+
+### Fixed
+
+* Apply Clippy updates from recent versions ([#46](https://github.com/scouten-adobe/jumbf-rs/pull/46))
+* Improve test coverage for `SuperBox` functions ([#23](https://github.com/scouten-adobe/jumbf-rs/pull/23))
+
+### Updated dependencies
+
+* Update thiserror requirement from 1.0.58 to 2.0.17 ([#55](https://github.com/scouten-adobe/jumbf-rs/pull/55))
+* Update codspeed-criterion-compat requirement from 2.4 to 4.2 ([#54](https://github.com/scouten-adobe/jumbf-rs/pull/54))
+* Update criterion requirement from 0.5.1 to 0.8.1 ([#53](https://github.com/scouten-adobe/jumbf-rs/pull/53))
+* Update hex-literal requirement from 0.4.1 to 1.1.0 ([#51](https://github.com/scouten-adobe/jumbf-rs/pull/51))
+
 ## [0.4.1](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.0...v0.4.1)
 _28 September 2024_
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ name = "jumbf"
 readme = "README.md"
 repository = "https://github.com/scouten-adobe/jumbf-rs"
 rust-version = "1.88.0"
-version = "0.4.1"
+version = "0.5.0"
 
 [features]
 default = ["parser"]


### PR DESCRIPTION



## 🤖 New release

* `jumbf`: 0.4.1 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/scouten-adobe/jumbf-rs/compare/v0.4.1...v0.5.0)

_22 January 2026_

### Added

* [**breaking**] Bump MSRV to 1.88.0 ([#47](https://github.com/scouten-adobe/jumbf-rs/pull/47))

### Fixed

* Apply Clippy updates from recent versions ([#46](https://github.com/scouten-adobe/jumbf-rs/pull/46))
* Improve test coverage for `SuperBox` functions ([#23](https://github.com/scouten-adobe/jumbf-rs/pull/23))

### Updated dependencies

* Update thiserror requirement from 1.0.58 to 2.0.17 ([#55](https://github.com/scouten-adobe/jumbf-rs/pull/55))
* Update codspeed-criterion-compat requirement from 2.4 to 4.2 ([#54](https://github.com/scouten-adobe/jumbf-rs/pull/54))
* Update criterion requirement from 0.5.1 to 0.8.1 ([#53](https://github.com/scouten-adobe/jumbf-rs/pull/53))
* Update hex-literal requirement from 0.4.1 to 1.1.0 ([#51](https://github.com/scouten-adobe/jumbf-rs/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).